### PR TITLE
added state-wise-v2 api call with district comparator

### DIFF
--- a/src/main/java/core/ApiCall.java
+++ b/src/main/java/core/ApiCall.java
@@ -8,6 +8,7 @@ public class ApiCall {
 
     public static final String RAW_DATA_URL = "https://api.covid19india.org/raw_data.json";
     public static final String STATE_DISTRICT_WISE_URL = "https://api.covid19india.org/state_district_wise.json";
+    public static final String STATE_DISTRICT_WISE_V2_URL = "https://api.covid19india.org/v2/state_district_wise.json";
     public static final String DATA_URL = "https://api.covid19india.org/data.json";
 
     public static String getDataFromApi(String urlString) throws Exception {

--- a/src/main/java/core/Main.java
+++ b/src/main/java/core/Main.java
@@ -4,10 +4,7 @@ import api.Data;
 import api.Statewise;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import process_data.DistrictDatum;
-import process_data.DistrictWise;
-import process_data.RawData;
-import process_data.RawDatum;
+import process_data.*;
 
 import java.util.*;
 
@@ -179,8 +176,43 @@ public class Main {
 		}
 	}
 
+	public static DistrictWise getDistrictWiseData(String state) {
+		try {
+			Gson gson = new GsonBuilder().setPrettyPrinting().create();
+			String jsonString = "{\"districtWise\":" + ApiCall.getDataFromApi(ApiCall.STATE_DISTRICT_WISE_V2_URL) + "}";
+
+			StateDistrictWise stateDistrictWise = gson.fromJson(jsonString, StateDistrictWise.class);
+			List<DistrictWise> districtWiseList = stateDistrictWise.getDistrictWise();
+			for (DistrictWise districtWiseObject: districtWiseList) {
+				if (districtWiseObject.getState().equalsIgnoreCase(state)) {
+					return districtWiseObject;
+				}
+				/*
+				System.out.println(districtWiseObject.getState());
+				List<DistrictDatum> districtDataList = districtWiseObject.getDistrictData();
+				Collections.sort(districtDataList, DistrictDatum.DistrictConfirmedComparatorDescendingOrder);
+				for (DistrictDatum districtDatumObject: districtDataList) {
+					System.out.println(districtDatumObject.getDistrict() + " " + districtDatumObject.getConfirmed());
+				}
+				System.out.println();
+				*/
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
 	public static void main(String[] args) throws Exception {
-		getRawData();
+		//getRawData();
 		getData();
+		DistrictWise districtWiseObject = getDistrictWiseData("maharashtra");
+		System.out.println("State " + districtWiseObject.getState());
+		List<DistrictDatum> districtDataList = districtWiseObject.getDistrictData();
+		Collections.sort(districtDataList, DistrictDatum.DistrictConfirmedComparatorDescendingOrder);
+		for (DistrictDatum districtDatumObject: districtDataList) {
+			System.out.println(districtDatumObject.getDistrict() + " " + districtDatumObject.getConfirmed());
+		}
 	}
 }

--- a/src/main/java/process_data/DistrictDatum.java
+++ b/src/main/java/process_data/DistrictDatum.java
@@ -3,6 +3,8 @@ package process_data;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Comparator;
+
 public class DistrictDatum {
 
 	@SerializedName("district")
@@ -49,4 +51,15 @@ public class DistrictDatum {
 	public void setDelta(Delta delta) {
 		this.delta = delta;
 	}
+
+	public static Comparator<DistrictDatum> DistrictConfirmedComparatorDescendingOrder = new Comparator<DistrictDatum>() {
+
+		public int compare(DistrictDatum districtDatum1, DistrictDatum districtDatum2) {
+			Integer confirmed1 = districtDatum1.getConfirmed();
+			Integer confirmed2 = districtDatum2.getConfirmed();
+
+			//descending order
+			return confirmed2 - confirmed1;
+		}
+	};
 }

--- a/src/main/java/process_data/StateDistrictWise.java
+++ b/src/main/java/process_data/StateDistrictWise.java
@@ -1,0 +1,21 @@
+package process_data;
+
+import java.util.List;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class StateDistrictWise {
+
+	@SerializedName("districtWise")
+	@Expose
+	private List<DistrictWise> districtWise = null;
+
+	public List<DistrictWise> getDistrictWise() {
+		return districtWise;
+	}
+
+	public void setDistrictWise(List<DistrictWise> districtWise) {
+		this.districtWise = districtWise;
+	}
+
+}


### PR DESCRIPTION
1.  Calls V2 API https://api.covid19india.org/v2/state_district_wise.json for StateWise data
2. Added comparator to sort DistrictWise list according to number of confirmed cases in state in descending order.